### PR TITLE
Add basic support for FOR { UPDATE | NO KEY UPDATE | SHARE | KEY SHARE }

### DIFF
--- a/src/keywords.ts
+++ b/src/keywords.ts
@@ -5,4 +5,5 @@ export const sqlKeywords = [
 
     // added manually
     , "PRECISION"
+    , "SHARE"
 ];

--- a/src/keywords.ts
+++ b/src/keywords.ts
@@ -5,5 +5,4 @@ export const sqlKeywords = [
 
     // added manually
     , "PRECISION"
-    , "SHARE"
 ];

--- a/src/syntax/ast.ts
+++ b/src/syntax/ast.ts
@@ -542,6 +542,7 @@ export interface SelectFromStatement extends PGNode {
     limit?: LimitStatement | nil;
     orderBy?: OrderByStatement[] | nil;
     distinct?: 'all' | 'distinct' | Expr[] | nil;
+    for?: ForStatement;
 }
 
 export interface SelectFromUnion extends PGNode {
@@ -553,6 +554,10 @@ export interface SelectFromUnion extends PGNode {
 export interface OrderByStatement extends PGNode {
     by: Expr;
     order?: 'ASC' | 'DESC' | nil;
+}
+
+export interface ForStatement extends PGNode {
+    type: 'update' | 'no_key_update' | 'share' | 'key_share';
 }
 
 export interface LimitStatement extends PGNode {

--- a/src/syntax/ast.ts
+++ b/src/syntax/ast.ts
@@ -557,7 +557,7 @@ export interface OrderByStatement extends PGNode {
 }
 
 export interface ForStatement extends PGNode {
-    type: 'update' | 'no_key_update' | 'share' | 'key_share';
+    type: 'update' | 'no key update' | 'share' | 'key share';
 }
 
 export interface LimitStatement extends PGNode {

--- a/src/syntax/base.ne
+++ b/src/syntax/base.ne
@@ -225,6 +225,7 @@ kw_local -> %word {% notReservedKw('local')  %}
 kw_prepare -> %word {% notReservedKw('prepare')  %}
 kw_raise -> %word {% notReservedKw('raise')  %}
 kw_continue -> %word {% notReservedKw('continue')  %}
+kw_share -> %word {% notReservedKw('share')  %}
 
 
 # === Composite keywords

--- a/src/syntax/select.ne
+++ b/src/syntax/select.ne
@@ -170,9 +170,9 @@ select_limit -> (%kw_limit expr_nostar {%last%}):?
 # FOR { UPDATE | NO KEY UPDATE | SHARE | KEY SHARE }
 select_for -> %kw_for (
     kw_update {% x => track(x, {type: 'update'}) %}
-    | kw_no kw_key kw_update {% x => track(x, {type: 'no_key_update'}) %}
-    | %kw_share {% x => track(x, {type: 'share'}) %}
-    | kw_key %kw_share {% x => track(x, {type: 'key_share'}) %})
+    | kw_no kw_key kw_update {% x => track(x, {type: 'no key update'}) %}
+    | kw_share {% x => track(x, {type: 'share'}) %}
+    | kw_key kw_share {% x => track(x, {type: 'key share'}) %})
 
 select_order_by -> (%kw_order kw_by) select_order_by_expr (comma select_order_by_expr {%last%}):*  {% ([_, head, tail]) => {
     return [head, ...(tail || [])];

--- a/src/syntax/select.spec.ts
+++ b/src/syntax/select.spec.ts
@@ -615,4 +615,40 @@ describe('Select statements', () => {
             }
         }),
     });
+
+    checkSelect('select * from test for update', {
+        type: 'select',
+        from: [tbl('test')],
+        columns: columns({ type: 'ref', name: '*' }),
+        for: {
+            type: 'update',
+        }
+    });
+
+    checkSelect('select * from test for no key update', {
+        type: 'select',
+        from: [tbl('test')],
+        columns: columns({ type: 'ref', name: '*' }),
+        for: {
+            type: 'no_key_update',
+        }
+    });
+
+    checkSelect('select * from test for share', {
+        type: 'select',
+        from: [tbl('test')],
+        columns: columns({ type: 'ref', name: '*' }),
+        for: {
+            type: 'share',
+        }
+    });
+
+    checkSelect('select * from test for key share', {
+        type: 'select',
+        from: [tbl('test')],
+        columns: columns({ type: 'ref', name: '*' }),
+        for: {
+            type: 'key_share',
+        }
+    });
 });

--- a/src/syntax/select.spec.ts
+++ b/src/syntax/select.spec.ts
@@ -630,7 +630,7 @@ describe('Select statements', () => {
         from: [tbl('test')],
         columns: columns({ type: 'ref', name: '*' }),
         for: {
-            type: 'no_key_update',
+            type: 'no key update',
         }
     });
 
@@ -648,7 +648,7 @@ describe('Select statements', () => {
         from: [tbl('test')],
         columns: columns({ type: 'ref', name: '*' }),
         for: {
-            type: 'key_share',
+            type: 'key share',
         }
     });
 });

--- a/src/to-sql.ts
+++ b/src/to-sql.ts
@@ -1183,6 +1183,27 @@ const visitor = astVisitor<IAstFullVisitor>(m => ({
                 m.expr(s.limit.limit);
             }
         }
+
+        if (s.for) {
+            ret.push('FOR ');
+            switch (s.for.type) {
+                case 'update':
+                    ret.push('UPDATE ');
+                    break;
+                case 'no_key_update':
+                    ret.push('NO ');
+                    ret.push('KEY ');
+                    ret.push('UPDATE ');
+                    break;
+                case 'share':
+                    ret.push('SHARE ');
+                    break;
+                case 'key_share':
+                    ret.push('KEY ');
+                    ret.push('SHARE ');
+                    break;
+            }
+        }
     },
 
     show: s => {

--- a/src/to-sql.ts
+++ b/src/to-sql.ts
@@ -1185,24 +1185,7 @@ const visitor = astVisitor<IAstFullVisitor>(m => ({
         }
 
         if (s.for) {
-            ret.push('FOR ');
-            switch (s.for.type) {
-                case 'update':
-                    ret.push('UPDATE ');
-                    break;
-                case 'no_key_update':
-                    ret.push('NO ');
-                    ret.push('KEY ');
-                    ret.push('UPDATE ');
-                    break;
-                case 'share':
-                    ret.push('SHARE ');
-                    break;
-                case 'key_share':
-                    ret.push('KEY ');
-                    ret.push('SHARE ');
-                    break;
-            }
+            ret.push('FOR ', s.for.type.toUpperCase());
         }
     },
 


### PR DESCRIPTION
This aims to solve https://github.com/oguimbal/pg-mem/issues/117

There were a couple of things I was unsure about and would like to get some feedback:
- I needed to add SHARE to the keyword list. Why not NO, KEY?
- Why do some key words need a '%' prefix, e.g. %kw_share (what does it do? I couldn't find any docs for it)
- I introduced `ForStatement extends PGNode` in `ast.ts`. However, I don't think I do anything to make it a PGNode, how to do it correctly?
- In to-sql.ts I don't call the `m: IAstVisitor`. Do I need to? if yes how?