### PR TITLE
Add support for timestamp precision and test specific cast

### DIFF
--- a/src/syntax/base.ne
+++ b/src/syntax/base.ne
@@ -267,7 +267,7 @@ data_type_list -> data_type (comma data_type {% last %}):* {% ([head, tail]) => 
 data_type_simple
     -> data_type_text {% x => track(x, { name: toStr(x, ' ') }) %}
     | data_type_numeric  {% x => track(x, { name: toStr(x, ' ') }) %}
-    | data_type_date  {% x => track(x, { name: toStr(x, ' ') }) %}
+    | data_type_date
     | qualified_name
     # | word {% anyKw('json', 'jsonb', 'boolean', 'bool', 'money', 'bytea', 'regtype') %}
 
@@ -283,6 +283,9 @@ data_type_text
 #https://www.postgresql.org/docs/9.5/datatype-datetime.html
 data_type_date
      ->  (%word {% anyKw('timestamp', 'time') %}) (%kw_with | %word {% kw('without') %}) (%word {% kw('time') %}) (%word {% kw('zone') %})
+        {% x => track(x, { name: toStr(x, ' ') }) %}
+     | (%word {% anyKw('timestamp', 'time') %}) (lparen int rparen {% get(1) %}) (%kw_with | %word {% kw('without') %}) (%word {% kw('time') %}) (%word {% kw('zone') %})
+        {% x => track(x, { name: `timestamp ${toStr(x[2])} time zone`, config: [unbox(x[1])] }) %}
 
 
 # === Table ref  (ex:  [db.]mytable [as X] )

--- a/src/syntax/expr.spec.ts
+++ b/src/syntax/expr.spec.ts
@@ -697,6 +697,19 @@ line`,
                 }
             },
         });
+
+        checkTreeExpr(`('now'::text)::timestamp(4) with time zone`, {
+            type: 'cast',
+            to: {
+                name: 'timestamp with time zone',
+                config: [4],
+            },
+            operand: {
+                type: 'cast',
+                to: { name: 'text' },
+                operand: { type: 'string', value: 'now' },
+            },
+        });
     });
 
 

--- a/src/to-sql.spec.ts
+++ b/src/to-sql.spec.ts
@@ -57,7 +57,7 @@ describe('SQL builder', () => {
             .to.equal(`(('2021-04-03 16:16:02')::timestamp with time zone )`);
 
         expect(expr(`('now'::text)::timestamp(4) with time zone`))
-            .to.equal(`(('now'::text)::timestamp(4) with time zone )`);
+            .to.equal(`((('now')::text )::timestamp(4) with time zone )`);
     });
 
 

--- a/src/to-sql.spec.ts
+++ b/src/to-sql.spec.ts
@@ -55,6 +55,9 @@ describe('SQL builder', () => {
 
         expect(expr(`'2021-04-03 16:16:02'::timestamp with time zone`))
             .to.equal(`(('2021-04-03 16:16:02')::timestamp with time zone )`);
+
+        expect(expr(`('now'::text)::timestamp(4) with time zone`))
+            .to.equal(`(('now'::text)::timestamp(4) with time zone )`);
     });
 
 

--- a/src/to-sql.ts
+++ b/src/to-sql.ts
@@ -794,20 +794,30 @@ const visitor = astVisitor<IAstFullVisitor>(m => ({
                 case 'double precision':
                 case 'character varying':
                 case 'bit varying':
+                    ret.push(d.name, ' ');
+
+                    if (d.config?.length) {
+                        list(d.config, v => ret.push(v.toString(10)), true);
+                    }
+
+                    break;
                 case 'time without time zone':
                 case 'timestamp without time zone':
                 case 'time with time zone':
                 case 'timestamp with time zone':
-                    ret.push(d.name, ' ');
+                    const parts = d.name.split(' ');
+
+                    ret.push(parts.shift()!);
+                    if (d.config?.length) {
+                        list(d.config, v => ret.push(v.toString(10)), true);
+                    }
+
+                    ret.push(parts.join(' '), ' ');
                     break;
                 default:
                     visitQualifiedName(d);
                     break;
             }
-        }
-
-        if (d.config?.length) {
-            list(d.config, v => ret.push(v.toString(10)), true);
         }
     },
 

--- a/src/to-sql.ts
+++ b/src/to-sql.ts
@@ -785,6 +785,7 @@ const visitor = astVisitor<IAstFullVisitor>(m => ({
             ret.push('unkown');
             return;
         }
+        let appendConfig = true;
         if (d.schema) {
             visitQualifiedName(d);
         } else {
@@ -795,11 +796,6 @@ const visitor = astVisitor<IAstFullVisitor>(m => ({
                 case 'character varying':
                 case 'bit varying':
                     ret.push(d.name, ' ');
-
-                    if (d.config?.length) {
-                        list(d.config, v => ret.push(v.toString(10)), true);
-                    }
-
                     break;
                 case 'time without time zone':
                 case 'timestamp without time zone':
@@ -811,13 +807,19 @@ const visitor = astVisitor<IAstFullVisitor>(m => ({
                     if (d.config?.length) {
                         list(d.config, v => ret.push(v.toString(10)), true);
                     }
+                    ret.push(' ');
 
                     ret.push(parts.join(' '), ' ');
+                    appendConfig = false;
                     break;
                 default:
                     visitQualifiedName(d);
                     break;
             }
+        }
+
+        if (appendConfig && d.config?.length) {
+            list(d.config, v => ret.push(v.toString(10)), true);
         }
     },
 


### PR DESCRIPTION
## Context

Working with `pg-mem`, I encountered an issue parsing a query autogenerated by TypeORM when synchronising schema:

`CREATE TABLE "company" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdTime" TIMESTAMP NOT NULL DEFAULT ('now'::text)::timestamp(4) with time zone);`

The problem was with `('now'::text)::timestamp(4) with time zone` specifically. Strangeness of this cast expression aside, it wasn't able to be parsed by `pgsql-ast-parser` due to the fact the timestamp's precision is after the keyword `timestamp` and not at the end of the type, as the grammar expects.

## Solution

* Edit the base grammar to support timestamp precision after the first keyword.
* Adjust `to-sql` logic to place precision after the entire type for `bit varying`, `character varying` etc., but after the keyword for `timestamp` and `time`.
* Add unit tests to validate the case presented above.