### PR TITLE
feature: added cross join support

### DIFF
--- a/src/ast-mapper.ts
+++ b/src/ast-mapper.ts
@@ -988,7 +988,7 @@ export class AstDefaultMapper implements IAstMapper {
     join(join: a.JoinClause): a.JoinClause | nil {
         const on = join.on && this.expr(join.on);
         if (!on && !join.using) {
-            return null;
+            return join;
         }
         return assignChanged(join, {
             on,

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -1,11 +1,12 @@
 import { compile, keywords } from 'moo';
-import { PGComment, NodeLocation } from './syntax/ast';
+
 import { sqlKeywords } from './keywords';
+import { NodeLocation, PGComment } from './syntax/ast';
 
 // build keywords
-const keywodsMap: any = {};
+const keywordsMap: any = {};
 for (const k of sqlKeywords) {
-    keywodsMap['kw_' + k.toLowerCase()] = k;
+    keywordsMap['kw_' + k.toLowerCase()] = k;
 }
 const caseInsensitiveKeywords = (map: any) => {
     const transform = keywords(map)
@@ -17,7 +18,7 @@ const caseInsensitiveKeywords = (map: any) => {
 export const lexer = compile({
     word: {
         match: /[eE](?!')[A-Za-z0-9_]*|[a-df-zA-DF-Z_][A-Za-z0-9_]*/,
-        type: caseInsensitiveKeywords(keywodsMap),
+        type: caseInsensitiveKeywords(keywordsMap),
         value: x => x.toLowerCase(),
     },
     wordQuoted: {

--- a/src/syntax/ast.ts
+++ b/src/syntax/ast.ts
@@ -674,7 +674,8 @@ export interface JoinClause extends PGNode {
 export type JoinType = 'INNER JOIN'
     | 'LEFT JOIN'
     | 'RIGHT JOIN'
-    | 'FULL JOIN';
+    | 'FULL JOIN'
+    | 'CROSS JOIN';
 
 export type Expr = ExprRef
     | ExprParameter

--- a/src/to-sql.ts
+++ b/src/to-sql.ts
@@ -1262,7 +1262,13 @@ const visitor = astVisitor<IAstFullVisitor>(m => ({
         ret.push(' ');
         if (s.from) {
             ret.push('FROM ');
-            for (const f of s.from) {
+            const tblCnt = s.from.length
+            for (let i = 0; i < tblCnt; i++) {
+                const f = s.from[i];
+                if (i > 0 && !f.join) {
+                    // implicit cross join (https://www.postgresql.org/docs/9.5/sql-select.html#SQL-FROM)
+                    ret.push(',')
+                }
                 m.from(f);
             }
             ret.push(' ');


### PR DESCRIPTION
This fixes https://github.com/oguimbal/pgsql-ast-parser/issues/49 and adds support for `CROSS JOIN` as well as selecting from multiple tables (implicit cross join).

I considered parsing `tableA, tableB` to the AST equivalent of a cross join, but figured it's better to keep things symmetric and instead allowed the `from` array to contain multiple tables, which don't necessarily have to be joins.

No existing tests were modified, so backward compatibility can be assumed.