### PR TITLE
feature: support `some` and `all` function expressions

### DIFF
--- a/src/syntax/expr.ne
+++ b/src/syntax/expr.ne
@@ -276,8 +276,8 @@ expr_fn_name -> ((word %dot):?  word_or_keyword {% x => track(x, {
             name: unbox(unwrap(x[1])),
             ...x[0] && { schema: toStr(x[0][0]) },
         })  %})
-    | (%kw_any {% x => track(x, {
-            name: 'any',
+    | ((%kw_any | %kw_some | %kw_all) {% x => track(x, {
+            name: toStr(unwrap(x)),
         })%})
 
 word_or_keyword

--- a/src/syntax/expr.spec.ts
+++ b/src/syntax/expr.spec.ts
@@ -1164,6 +1164,33 @@ line`,
             }],
         });
 
+        checkTreeExprLoc([`some(c)`], { // alias for any
+            _location: { start: 0, end: 7 },
+            type: 'call',
+            function: {
+                _location: { start: 0, end: 4 },
+                name: 'some'
+            },
+            args: [{
+                _location: { start: 5, end: 6 },
+                type: 'ref',
+                name: 'c'
+            }],
+        });
+
+        checkTreeExprLoc([`all(c)`], {
+            _location: { start: 0, end: 6 },
+            type: 'call',
+            function: {
+                _location: { start: 0, end: 3 },
+                name: 'all'
+            },
+            args: [{
+                _location: { start: 4, end: 5 },
+                type: 'ref',
+                name: 'c'
+            }],
+        });
 
         checkTreeExprLoc([`now()`], {
             _location: { start: 0, end: 5 },


### PR DESCRIPTION
This adds support for `some` and `all`, as outlined in https://github.com/oguimbal/pgsql-ast-parser/issues/70.

I don't know how aliases have been treated in the past, but I think `some` should be preserved in the AST, rather than parsing it to `any`, to preserve symmetry.