### PR TITLE
feature: added deallocate statement

### DIFF
--- a/src/ast-mapper.ts
+++ b/src/ast-mapper.ts
@@ -26,6 +26,7 @@ export interface IAstPartialMapper {
     set?: (st: a.SetStatement) => a.SetStatement | nil
     dataType?: (dataType: a.DataTypeDef) => a.DataTypeDef
     prepare?: (st: a.PrepareStatement) => a.Statement | nil
+    deallocate?: (st: a.DeallocateStatement) => a.Statement | nil
     parameter?: (st: a.ExprParameter) => a.Expr | nil
     tableRef?: (st: a.QNameAliased) => a.QNameAliased | nil
     transaction?: (val: a.CommitStatement | a.RollbackStatement | a.StartTransactionStatement) => a.Statement | nil
@@ -269,6 +270,8 @@ export class AstDefaultMapper implements IAstMapper {
                 return this.show(val);
             case 'prepare':
                 return this.prepare(val);
+            case 'deallocate':
+                return this.deallocate(val);
             case 'create view':
                 return this.createView(val);
             case 'create materialized view':
@@ -656,6 +659,10 @@ export class AstDefaultMapper implements IAstMapper {
             args: arrayNilMap(st.args, a => this.dataType(a)),
             statement,
         })
+    }
+
+    deallocate(st: a.DeallocateStatement): a.Statement | nil {
+        return st;
     }
 
     // =========================================

--- a/src/syntax/ast.ts
+++ b/src/syntax/ast.ts
@@ -19,6 +19,7 @@ export type Statement = SelectStatement
     | UpdateStatement
     | ShowStatement
     | PrepareStatement
+    | DeallocateStatement
     | DeleteStatement
     | WithStatement
     | RollbackStatement
@@ -146,6 +147,11 @@ export interface PrepareStatement extends PGNode {
     name: Name;
     args?: DataTypeDef[] | nil;
     statement: Statement;
+}
+
+export interface DeallocateStatement extends PGNode {
+    type: 'deallocate';
+    target: Name | { option: 'all' };
 }
 
 export interface CreateEnumType extends PGNode {

--- a/src/syntax/ast.ts
+++ b/src/syntax/ast.ts
@@ -151,7 +151,11 @@ export interface PrepareStatement extends PGNode {
 
 export interface DeallocateStatement extends PGNode {
     type: 'deallocate';
-    target: Name | { option: 'all' };
+    target: Name | DeallocateStatementOpt;
+}
+
+export interface DeallocateStatementOpt extends PGNode {
+    option: 'all';
 }
 
 export interface CreateEnumType extends PGNode {

--- a/src/syntax/base.ne
+++ b/src/syntax/base.ne
@@ -225,6 +225,7 @@ kw_hour -> %word {% notReservedKw('hour')  %}
 kw_minute -> %word {% notReservedKw('minute')  %}
 kw_local -> %word {% notReservedKw('local')  %}
 kw_prepare -> %word {% notReservedKw('prepare')  %}
+kw_deallocate -> %word {% notReservedKw('deallocate')  %}
 kw_raise -> %word {% notReservedKw('raise')  %}
 kw_continue -> %word {% notReservedKw('continue')  %}
 kw_share -> %word {% notReservedKw('share')  %}

--- a/src/syntax/deallocate.ne
+++ b/src/syntax/deallocate.ne
@@ -1,0 +1,13 @@
+@lexer lexerAny
+
+deallocate -> kw_deallocate kw_prepare:? deallocate_target {% x => track(x, {
+        type: 'deallocate',
+        target: x[2],
+    }) %}
+
+deallocate_target
+    -> deallocate_all {% unwrap %}
+    | deallocate_name  {% unwrap %}
+
+deallocate_name -> ident {% x => track(x, asName(x[0]) ) %}
+deallocate_all -> %kw_all  {% x => track(x, { option: 'all' }) %}

--- a/src/syntax/deallocate.spec.ts
+++ b/src/syntax/deallocate.spec.ts
@@ -1,0 +1,19 @@
+import 'mocha';
+import 'chai';
+
+import { checkStatement } from './spec-utils';
+
+describe('Create types', () => {
+	checkStatement(['DEALLOCATE identifier', 'DEALLOCATE PREPARE identifier'], {
+		target: {
+			name: 'identifier',
+		},
+		type: 'deallocate',
+	});
+	checkStatement(['DEALLOCATE ALL', 'DEALLOCATE PREPARE ALL'], {
+		target: {
+			option: 'all',
+		},
+		type: 'deallocate',
+	});
+});

--- a/src/syntax/main.ne
+++ b/src/syntax/main.ne
@@ -21,6 +21,7 @@ import {lexerAny} from '../lexer';
 @include "create-type.ne"
 @include "union.ne"
 @include "prepare.ne"
+@include "deallocate.ne"
 @include "create-view.ne"
 @include "functions.ne"
 
@@ -38,7 +39,7 @@ main -> statement_separator:* statement (statement_separator:+ statement):* stat
 statement_separator -> %semicolon
 
 
-statement -> statement_noprep | prepare
+statement -> statement_noprep | prepare | deallocate
 
 statement_noprep
     -> selection

--- a/src/to-sql.ts
+++ b/src/to-sql.ts
@@ -1321,6 +1321,15 @@ const visitor = astVisitor<IAstFullVisitor>(m => ({
         m.statement(s.statement);
     },
 
+    deallocate: s => {
+        ret.push('DEALLOCATE ');
+        if ('name' in s.target) {
+            ret.push(s.target.name);
+            return;
+        }
+        ret.push('ALL')
+    },
+
     arraySelect: s => {
         ret.push('array(');
         m.select(s.select);


### PR DESCRIPTION
It seems I am addicted to nearley now. And I blame @oguimbal.

This fixes https://github.com/oguimbal/pgsql-ast-parser/issues/45

I wasn't quite sure what the expected AST should look like here, and tried to mimic other trees.

I ended up with these:
```sql
DEALLOCATE identifier
```
⏬  ⏬  ⏬  ⏬  ⏬  ⏬  
```javascript
{
    type: 'deallocate',
    target: {
        name: 'identifier',
    },
}
```
and

```sql
DEALLOCATE ALL
```
⏬  ⏬  ⏬  ⏬  ⏬  ⏬  
```javascript
{
    type: 'deallocate',
    target: {
        option: 'all',
    },
}
```

It would of course be possible to make them more similar and just pretend `'all'` is a name. But I kind of felt that to be imprecise.

I am more than open to suggestions for a different AST output, if you have an idea?