### PR TITLE
test: add failing case illustrating issue #83

### DIFF
--- a/src/ast-mapper.spec.ts
+++ b/src/ast-mapper.spec.ts
@@ -27,6 +27,15 @@ describe('Ast mapper', () => {
         })
     }
 
+    function testExprs(statement: string, map: MapperBuilder, exprs: Expr[]) {
+        const toMap = parse(statement);
+        const mapped = astMapper(map).statement(toMap);
+        assert.deepEqual(mapped, {
+            type: 'select',
+            columns: exprs.map(expr => ({ expr })),
+        })
+    }
+
     it('maps a select constant', () => {
         testExpr('select 42', b => ({
             constant: c => assignChanged(c, {
@@ -123,6 +132,22 @@ describe('Ast mapper', () => {
         });
     })
 
+    it('maps multiple calls', () => {
+        testExprs('select fn(a), fn(b), fn(c)', () => ({
+            call: c => c.args[0],
+        }), [
+            {
+                type: 'ref',
+                name: 'a',
+            }, {
+                type: 'ref',
+                name: 'b',
+            }, {
+                type: 'ref',
+                name: 'c',
+            }
+        ]);
+    })
 
     it('maps array literal', () => {
         testExpr('select (a,b)', b => ({

--- a/src/ast-mapper.ts
+++ b/src/ast-mapper.ts
@@ -167,7 +167,7 @@ export function arrayNilMap<T extends Object>(this: void, collection: T[] | nil,
     for (let i = 0; i < collection.length; i++) {
         const orig = collection[i];
         const val = mapper(orig);
-        if (!val || val !== orig) {
+        if (!changed && (!val || val !== orig)) {
             changed = true;
             ret = collection.slice(0, i);
         }


### PR DESCRIPTION
Add a test case where I expect all three `fn(X)` call expressions to be mapped by the `astMapper` invocation, but only one of them is.