### PR TITLE
Remove negative lookbehind usage from lexer to support Safari

### DIFF
--- a/src/lexer.spec.ts
+++ b/src/lexer.spec.ts
@@ -28,6 +28,51 @@ describe('Lexer', () => {
         expect(result).to.deep.equal(expected);
     }
 
+    it('comments and minus are not confused', () => {
+        lexer.reset(`1 - 2`);
+        next({ type: 'int', value: '1' });
+        next({ type: 'op_minus' });
+        next({ type: 'int', value: '2' });
+
+        lexer.reset(`1 -- 2`);
+        next({ type: 'int', value: '1' });
+        expect(lexer.next()).to.equal(undefined)
+    });
+
+    it('member and minus ops are not confused', () => {
+        lexer.reset(`- -> ->>`);
+        next({ type: 'op_minus'});
+        next({ type: 'op_member'});
+        next({ type: 'op_membertext'});
+    });
+
+    it('comments and division are not confused', () => {
+        lexer.reset(`1 / 2`);
+        next({ type: 'int', value: '1' });
+        next({ type: 'op_div' });
+        next({ type: 'int', value: '2' });
+
+        lexer.reset(`1 /* 2 */`);
+        next({ type: 'int', value: '1' });
+        expect(lexer.next()).to.equal(undefined)
+    });
+
+    it('like/ilike ops', () => {
+        lexer.reset(`!~~*`);
+        next({ type: 'op_not_ilike' });
+
+        lexer.reset(`!~~ *`);
+        next({ type: 'op_not_like' });
+        next({ type: 'star' });
+
+        lexer.reset(`~~*`);
+        next({ type: 'op_ilike' });
+
+        lexer.reset(`~~ *`);
+        next({ type: 'op_like' });
+        next({ type: 'star' });
+    });
+
     it('tokenizes end comment', () => {
         lexer.reset(`SELECT -- test`);
         next({ type: 'kw_select' });

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -46,7 +46,7 @@ export const lexer = compile({
         match: /\$\d+/,
     },
     commentLine: /\-\-.*?$[\s\r\n]*/,
-    commentFullOpen: /(?<!\/)\/\*/,
+    commentFullOpen: /\/\*/,
     commentFullClose: /\*\/[\s\r\n]*/,
     star: '*',
     comma: ',',
@@ -67,16 +67,16 @@ export const lexer = compile({
         match: /(?:!=)|(?:\<\>)/,
         value: () => '!=',
     },
-    op_minus: /(?<!\-)\-(?!\-)(?!\>)/,
-    op_div: /(?<!\/)\/(?!\/)/,
-    op_like: /(?<!\!)~~(?!\*)/, // ~~ =LIKE
-    op_ilike: /(?<!\!)~~\*/, // ~~* =ILIKE
-    op_not_like: /\!~~(?!\*)/, // !~~ =LIKE
+    op_membertext: '->>',
+    op_member: '->',
+    op_minus: '-',
+    op_div: /\//,
     op_not_ilike: /\!~~\*/, // !~~* =ILIKE
+    op_not_like: /\!~~/, // !~~ =LIKE
+    op_ilike: /~~\*/, // ~~* =ILIKE
+    op_like: /~~/, // ~~ =LIKE
     op_mod: '%',
     op_exp: '^',
-    op_member: /\-\>(?!\>)/,
-    op_membertext: '->>',
     op_additive: {
         // group other additive operators
         match: ['||', '-', '#-', '&&'],


### PR DESCRIPTION
The tests seem to pass, and I've created a few new ones just to make sure. However I'm still not 100% sure that this doesn't introduce regressions. I'm not great with advanced regex functionality such as negative lookbehinds.

This is meant to close https://github.com/oguimbal/pgsql-ast-parser/issues/34