### PR TITLE
Upgrade webpack-dev-server to 4.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,13 +64,13 @@
     "nyc": "^15.1.0",
     "rimraf": "^3.0.2",
     "source-map-support": "^0.5.19",
-    "ts-node": "^8.10.2",
     "ts-loader": "^8.0.0",
+    "ts-node": "^8.10.2",
     "typescript": "^3.9.6",
     "vscode-mocha-hmr": "^1.0.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12",
-    "webpack-dev-server": "^3.11.0",
+    "webpack-dev-server": "^4.10.0",
     "webpack-node-externals": "^1.7.2"
   },
   "nyc": {


### PR DESCRIPTION
Addresses https://nvd.nist.gov/vuln/detail/CVE-2022-0122 and https://www.huntr.dev/bounties/41852c50-3c6d-4703-8c55-4db27164a4ae/

(Not super likely to be exploitable, of course, but no particular reason to stick with the unpatched versions either.)