### PR TITLE
feat: support `expr WITHIN GROUP (ORDER BY expr)`

### DIFF
--- a/src/ast-mapper.ts
+++ b/src/ast-mapper.ts
@@ -1234,10 +1234,13 @@ export class AstDefaultMapper implements IAstMapper {
         }
         const orderBy = this.orderBy(val.orderBy);
         const filter = this.expr(val.filter);
+        const withinGroupList = val.withinGroup ? [val.withinGroup] : undefined
+        const withinGroup = this.orderBy(withinGroupList)?.[0];
         return assignChanged(val, {
             args,
             orderBy,
             filter,
+            withinGroup,
         });
     }
 

--- a/src/syntax/ast.ts
+++ b/src/syntax/ast.ts
@@ -898,6 +898,8 @@ export interface ExprCall extends PGNode {
     orderBy?: OrderByStatement[] | nil;
     /** [AGGREGATION FUNCTIONS] Filter clause */
     filter?: Expr | nil;
+    /** [AGGREGATION FUNCTIONS] WITHIN GROUP clause */
+    withinGroup?: OrderByStatement | nil;
     /** [AGGREGATION FUNCTIONS] OVER clause */
     over?: CallOver | nil;
 }

--- a/src/syntax/base.ne
+++ b/src/syntax/base.ne
@@ -243,6 +243,7 @@ kw_refresh -> %word {% notReservedKw('refresh')  %}
 kw_nowait -> %word {% notReservedKw('nowait')  %}
 kw_skip -> %word {% notReservedKw('skip')  %}
 kw_locked -> %word {% notReservedKw('locked')  %}
+kw_within -> %word {% notReservedKw('within')  %}
 
 
 # === Composite keywords

--- a/src/syntax/expr.ne
+++ b/src/syntax/expr.ne
@@ -203,6 +203,7 @@ expr_call -> expr_fn_name
                 select_order_by:?
             rparen
             (kw_filter lparen %kw_where expr rparen {% get(3) %}):?
+            expr_call_within_group:?
             expr_call_over:?
             {% x => track(x, {
                 type: 'call',
@@ -211,7 +212,8 @@ expr_call -> expr_fn_name
                 args: x[3] || [],
                 ...x[4] && {orderBy: x[4]},
                 ...x[6] && {filter: unwrap(x[6])},
-                ...x[7] && {over: unwrap(x[7])},
+                ...x[7] && {withinGroup: x[7]},
+                ...x[8] && {over: unwrap(x[8])},
             }) %}
 
 expr_call_over -> kw_over
@@ -222,6 +224,13 @@ expr_call_over -> kw_over
                 ...x[2] && { partitionBy: x[2] },
                 ...x[3] && { orderBy: x[3] },
             }) %}
+
+expr_call_within_group -> (kw_within %kw_group)
+            lparen
+                (%kw_order kw_by)
+                select_order_by_expr
+            rparen
+            {% x => track(x, x[3]) %}
 
 # https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT
 expr_extract -> (word {% kw('extract') %}) lparen word %kw_from expr rparen {% x => track(x, {

--- a/src/syntax/expr.spec.ts
+++ b/src/syntax/expr.spec.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import 'chai';
-import { checkTreeExpr, checkInvalidExpr, checkInvalid, checkTreeExprLoc, starCol, star, col, ref, tbl, name } from './spec-utils';
+import { checkTreeExpr, checkInvalidExpr, checkInvalid, checkTreeExprLoc, starCol, star, col, ref, tbl, name, numeric } from './spec-utils';
 import { toSql } from '../to-sql';
 import { expect } from 'chai';
 import { parse } from '../parser';
@@ -1573,6 +1573,13 @@ line`,
             function: { name: 'count' },
             args: [ref('c')],
             orderBy: [{ by: ref('o') }]
+        });
+
+        checkTreeExpr(`PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY a)`, {
+            type: 'call',
+            function: { name: 'percentile_disc' },
+            args: [numeric(0.5)],
+            withinGroup: { by: ref('a') }
         });
     })
 

--- a/src/syntax/spec-utils.ts
+++ b/src/syntax/spec-utils.ts
@@ -2,7 +2,7 @@ import { Parser, Grammar } from 'nearley';
 import { expect, assert } from 'chai';
 import grammar from '../syntax/main.ne';
 import { trimNullish } from '../utils';
-import { Expr, SelectStatement, CreateTableStatement, CreateIndexStatement, Statement, InsertStatement, UpdateStatement, AlterTableStatement, DeleteStatement, CreateExtensionStatement, CreateSequenceStatement, AlterSequenceStatement, SelectedColumn, Interval, BinaryOperator, ExprBinary, Name, ExprInteger, FromTable, QName, AlterIndexStatement } from './ast';
+import { Expr, SelectStatement, CreateTableStatement, CreateIndexStatement, Statement, InsertStatement, UpdateStatement, AlterTableStatement, DeleteStatement, CreateExtensionStatement, CreateSequenceStatement, AlterSequenceStatement, SelectedColumn, Interval, BinaryOperator, ExprBinary, Name, ExprInteger, FromTable, QName, AlterIndexStatement, ExprNumeric } from './ast';
 import { astMapper, IAstMapper } from '../ast-mapper';
 import { toSql, IAstToSql } from '../to-sql';
 import { parseIntervalLiteral } from '../parser';
@@ -327,4 +327,7 @@ export function tbl(nm: string): FromTable {
         type: 'table',
         name: name(nm),
     };
+}
+export function numeric(value: number): ExprNumeric {
+    return { type: 'numeric', value };
 }

--- a/src/to-sql.ts
+++ b/src/to-sql.ts
@@ -490,6 +490,11 @@ const visitor = astVisitor<IAstFullVisitor>(m => ({
             m.expr(v.filter);
             ret.push(') ');
         }
+        if (v.withinGroup) {
+            ret.push('WITHIN GROUP (');
+            visitOrderBy(m, [v.withinGroup]);
+            ret.push(') ');
+        }
         if (v.over) {
             ret.push('over (');
             if (v.over.partitionBy) {


### PR DESCRIPTION
Adds support for `WITHIN GROUP` after a expression call.