### PR TITLE
feat: support `SET NAMES 'utf8'` statement

### DIFF
--- a/src/ast-mapper.ts
+++ b/src/ast-mapper.ts
@@ -84,6 +84,7 @@ export interface IAstPartialMapper {
     tablespace?(val: a.TablespaceStatement): a.Statement | nil
     setGlobal?(val: a.SetGlobalStatement): a.Statement | nil
     setTimezone?(val: a.SetTimezone): a.Statement | nil
+    setNames?(val: a.SetNames): a.Statement | nil
     createSequence?(seq: a.CreateSequenceStatement): a.Statement | nil
     alterSequence?(seq: a.AlterSequenceStatement): a.Statement | nil
     begin?(begin: a.BeginStatement): a.Statement | nil
@@ -249,6 +250,8 @@ export class AstDefaultMapper implements IAstMapper {
                 return this.setGlobal(val);
             case 'set timezone':
                 return this.setTimezone(val);
+            case 'set names':
+                return this.setNames(val);
             case 'create sequence':
                 return this.createSequence(val);
             case 'alter sequence':
@@ -440,6 +443,9 @@ export class AstDefaultMapper implements IAstMapper {
         return val;
     }
 
+    setNames(val: a.SetNames): a.Statement | nil {
+        return val;
+    }
 
     update(val: a.UpdateStatement): a.Statement | nil {
         if (!val) {

--- a/src/syntax/ast.ts
+++ b/src/syntax/ast.ts
@@ -32,6 +32,7 @@ export type Statement = SelectStatement
     | AlterSequenceStatement
     | SetGlobalStatement
     | SetTimezone
+    | SetNames
     | CreateEnumType
     | CreateCompositeType
     | TruncateTableStatement
@@ -987,6 +988,16 @@ export type SetTimezoneValue = {
     type: 'local' | 'default';
 } | {
     type: 'interval';
+    value: string;
+};
+
+export interface SetNames extends PGNode {
+    type: 'set names',
+    to: SetNamesValue;
+}
+
+export type SetNamesValue = {
+    type: 'value';
     value: string;
 };
 

--- a/src/syntax/base.ne
+++ b/src/syntax/base.ne
@@ -228,6 +228,7 @@ kw_over -> %word {% notReservedKw('over')  %}
 kw_system -> %word {% notReservedKw('system')  %}
 kw_comment -> %word {% notReservedKw('comment')  %}
 kw_time -> %word {% notReservedKw('time')  %}
+kw_names -> %word {% notReservedKw('names')  %}
 kw_at -> %word {% notReservedKw('at')  %}
 kw_zone -> %word {% notReservedKw('zone')  %}
 kw_interval -> %word {% notReservedKw('interval')  %}

--- a/src/syntax/simple-statements.ne
+++ b/src/syntax/simple-statements.ne
@@ -34,7 +34,7 @@ simplestatements_tablespace -> kw_tablespace word {% x => track(x, {
  }) %}
 
 
-simplestatements_set -> kw_set (simplestatements_set_simple | simplestatements_set_timezone) {% last %}
+simplestatements_set -> kw_set (simplestatements_set_simple | simplestatements_set_timezone | simplestatements_set_names) {% last %}
 
 simplestatements_set_timezone -> kw_time kw_zone simplestatements_set_timezone_val {% x => track(x, { type: 'set timezone', to: x[2] }) %}
 
@@ -43,6 +43,11 @@ simplestatements_set_timezone_val
     | kw_local {% x => track(x, { type: 'local'}) %}
     | %kw_default  {% x => track(x, { type: 'default'}) %}
     | kw_interval string kw_hour %kw_to kw_minute  {% x => track(x, { type: 'interval', value: unbox(x[1]) }) %}
+
+simplestatements_set_names -> kw_names simplestatements_set_names_val {% x => track(x, { type: 'set names', to: x[1] }) %}
+
+simplestatements_set_names_val
+    -> (string) {% x => track(x, { type: 'value', value: unwrap(x[0]) }) %}
 
 simplestatements_set_simple -> ident (%op_eq | %kw_to) simplestatements_set_val {% x  => track(x, {
         type: 'set',

--- a/src/syntax/simple-statements.spec.ts
+++ b/src/syntax/simple-statements.spec.ts
@@ -106,6 +106,13 @@ describe('Simple statements', () => {
         },
     });
 
+    checkStatement(`SET NAMES 'utf8'`, {
+        type: 'set names',
+        to: {
+            type: 'value',
+            value: 'utf8',
+        },
+    });
 
     checkStatement(['create schema test'], {
         type: 'create schema',

--- a/src/to-sql.ts
+++ b/src/to-sql.ts
@@ -817,6 +817,15 @@ const visitor = astVisitor<IAstFullVisitor>(m => ({
         }
     },
 
+    setNames: g => {
+        ret.push('SET NAMES ');
+        switch (g.to.type) {
+            case 'value':
+                ret.push(literal(g.to.value));
+                break;
+        }
+    },
+
     dataType: d => {
         if (d?.kind === 'array') {
             m.dataType(d.arrayOf!)


### PR DESCRIPTION
I blindly added support for `SET NAMES 'utf8'` which is issued by some ORMs.
Let me know if something is missing/needs to be changed.