### PR TITLE
Add support for SQL functions named left or right

### DIFF
--- a/.deno/syntax/main.ne.ts
+++ b/.deno/syntax/main.ne.ts
@@ -1620,6 +1620,8 @@ const grammar: Grammar = {
     {"name": "expr_fn_name$subexpression$2$subexpression$1", "symbols": [(lexerAny.has("kw_any") ? {type: "kw_any"} : kw_any)]},
     {"name": "expr_fn_name$subexpression$2$subexpression$1", "symbols": [(lexerAny.has("kw_some") ? {type: "kw_some"} : kw_some)]},
     {"name": "expr_fn_name$subexpression$2$subexpression$1", "symbols": [(lexerAny.has("kw_all") ? {type: "kw_all"} : kw_all)]},
+    {"name": "expr_fn_name$subexpression$2$subexpression$1", "symbols": [(lexerAny.has("kw_left") ? {type: "kw_left"} : kw_left)]},
+    {"name": "expr_fn_name$subexpression$2$subexpression$1", "symbols": [(lexerAny.has("kw_right") ? {type: "kw_right"} : kw_right)]},
     {"name": "expr_fn_name$subexpression$2", "symbols": ["expr_fn_name$subexpression$2$subexpression$1"], "postprocess":  x => track(x, {
             name: toStr(unwrap(x)),
         })},

--- a/src/syntax/expr.ne
+++ b/src/syntax/expr.ne
@@ -287,7 +287,7 @@ expr_fn_name -> ((word %dot):?  word_or_keyword {% x => track(x, {
             name: unbox(unwrap(x[1])),
             ...x[0] && { schema: toStr(x[0][0]) },
         })  %})
-    | ((%kw_any | %kw_some | %kw_all) {% x => track(x, {
+    | ((%kw_any | %kw_some | %kw_all | %kw_left | %kw_right) {% x => track(x, {
             name: toStr(unwrap(x)),
         })%})
 

--- a/src/syntax/expr.spec.ts
+++ b/src/syntax/expr.spec.ts
@@ -1247,6 +1247,20 @@ line`,
             args: [],
         });
 
+        checkTreeExprLoc([`left('foo')`], {
+            _location: { start: 0, end: 11 },
+            type: 'call',
+            function: {
+                _location: { start: 0, end: 4 },
+                name: 'left'
+            },
+            args: [{
+                _location: { start: 5, end: 10 },
+                type: 'string',
+                value: 'foo'
+            }],
+        });
+
         checkTreeExprLoc([`pg_catalog.col_description(23208,4)`], {
             _location: { start: 0, end: 35 },
             type: 'call',


### PR DESCRIPTION
These functions collide with SQL keywords such that they didn't parse before this change. But, they are valid PG function names, so these tokens should be included in the fn_name rule.

Fixes #118 