### PR TITLE
fix: binop minus without space

### DIFF
--- a/src/lexer.spec.ts
+++ b/src/lexer.spec.ts
@@ -168,15 +168,18 @@ describe('Lexer', () => {
         next({ type: 'comma' });
         next({ type: 'float', value: '.1' });
         next({ type: 'comma' });
-        next({ type: 'float', value: '-.1' });
+        next({ type: 'op_minus' });
+        next({ type: 'float', value: '.1' });
         next({ type: 'comma' });
-        next({ type: 'float', value: '-0.1' });
+        next({ type: 'op_minus' });
+        next({ type: 'float', value: '0.1' });
         next({ type: 'comma' });
         next({ type: 'float', value: '0.1' });
         next({ type: 'comma' });
         next({ type: 'float', value: '10.' });
         next({ type: 'comma' });
-        next({ type: 'float', value: '-10.' });
+        next({ type: 'op_minus' });
+        next({ type: 'float', value: '10.' });
     })
 
     it('tokenizes ->', () => {

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -51,8 +51,6 @@ export const lexer = compile({
     star: '*',
     comma: ',',
     space: { match: /[\s\t\n\v\f\r]+/, lineBreaks: true, },
-    int: /\-?\d+(?![\.\d])/,
-    float: /\-?(?:(?:\d*\.\d+)|(?:\d+\.\d*))/,
     // word: /[a-zA-Z][A-Za-z0-9_\-]*/,
     lparen: '(',
     rparen: ')',
@@ -71,6 +69,8 @@ export const lexer = compile({
     op_membertext: '->>',
     op_member: '->',
     op_minus: '-',
+    int: /\-?\d+(?![\.\d])/,
+    float: /\-?(?:(?:\d*\.\d+)|(?:\d+\.\d*))/,
     op_div: /\//,
     op_not_ilike: /\!~~\*/, // !~~* =ILIKE
     op_not_like: /\!~~/, // !~~ =LIKE

--- a/src/syntax/expr.ne
+++ b/src/syntax/expr.ne
@@ -107,7 +107,13 @@ expr_array_index
     | expr_member {% unwrap %}
 
 expr_member
-    -> (expr_member | expr_paren) ops_member (string | int) {% x => track(x, {
+    -> (expr_member | expr_paren) ops_member %op_minus int {% x => track(x, {
+            type: 'member',
+            operand: unwrap(x[0]),
+            op: x[1],
+            member: -unwrap(x[3])
+        }) %}
+    | (expr_member | expr_paren) ops_member (string | int) {% x => track(x, {
             type: 'member',
             operand: unwrap(x[0]),
             op: x[1],

--- a/src/syntax/expr.spec.ts
+++ b/src/syntax/expr.spec.ts
@@ -46,18 +46,37 @@ describe('Expressions', () => {
         });
 
         checkTreeExpr(['-0.5', '-.5'], {
-            type: 'numeric',
-            value: -0.5,
+            type: 'unary',
+            op: '-',
+            operand: {
+                type: 'numeric',
+                value: 0.5,
+            }
         });
 
         checkTreeExpr(['-42.', '-42.0'], {
-            type: 'numeric',
-            value: -42,
+            type: 'unary',
+            op: '-',
+            operand: {
+                type: 'numeric',
+                value: 42,
+            }
         });
 
         checkInvalidExpr('42. 51');
 
-        checkInvalidExpr('42.-51');
+        checkTreeExpr(['42.-51'], {
+            type: 'binary',
+            op: '-',
+            left: {
+                type: 'numeric',
+                value: 42,
+            },
+            right: {
+                type: 'integer',
+                value: 51,
+            },
+        });
 
         checkTreeExprLoc(['null'], {
             _location: { start: 0, end: 4 },

--- a/src/syntax/expr.spec.ts
+++ b/src/syntax/expr.spec.ts
@@ -400,6 +400,19 @@ line`,
             }
         });
 
+        checkTreeExpr(['42-51', '42 - 51'], {
+            type: 'binary',
+            op: '-',
+            left: {
+                type: 'integer',
+                value: 42,
+            },
+            right: {
+                type: 'integer',
+                value: 51,
+            }
+        });
+
         checkTreeExpr(['42*51', '42 * 51'], {
             type: 'binary',
             op: '*',

--- a/src/syntax/simple-statements.ne
+++ b/src/syntax/simple-statements.ne
@@ -40,6 +40,7 @@ simplestatements_set_timezone -> kw_time kw_zone simplestatements_set_timezone_v
 
 simplestatements_set_timezone_val
     -> (string | int) {% x => track(x, { type: 'value', value: unwrap(x[0]) }) %}
+    | %op_minus int {% x => track(x, { type: 'value', value: -unwrap(x[1]) }) %}
     | kw_local {% x => track(x, { type: 'local'}) %}
     | %kw_default  {% x => track(x, { type: 'default'}) %}
     | kw_interval string kw_hour %kw_to kw_minute  {% x => track(x, { type: 'interval', value: unbox(x[1]) }) %}


### PR DESCRIPTION
What
---

Fix the bug that the expression `42-51` fails to parse, because the tokenizer greedily treats `-51` as being a number token.

Closes #133

How
---

Move the lexer definitions for `int` and `float` to be below the `op_minus` definition. This changes the precedence so that the lexer emits a unary minus followed by an integer, rather than emitting a single negative-integer token.

Update tests in `src/lexer.spec.ts` to expect this.

Update tests in `src/syntax/expr.spec.ts` to expect the resulting wrapping of integer literals with `type: unary` AST nodes. In particular, replace the incorrect assertion `checkInvalidExpr('42.-51');` with one expecting a `binary` AST node because that expression _is_ valid.

Change the parser definitions `expr_member` and `simplestatements_set_timezone_val` to parse the unary-followed-by-integer token sequence as a negative integer, as that is the only thing that makes sense in those expressions, and it limits the footprint of the change.