### PR TITLE
Fix table alias location tracking

### DIFF
--- a/src/syntax/base.ne
+++ b/src/syntax/base.ne
@@ -312,7 +312,7 @@ data_type_date
 # === Table ref  (ex:  [db.]mytable [as X] )
 
 # [AS x] or just [x]
-ident_aliased -> (%kw_as ident {% last %}) | ident {% unwrap %}
+ident_aliased -> (%kw_as ident {% last %}) | ident {% last %}
 
 table_ref -> qualified_name {% unwrap %}
 

--- a/src/syntax/select.spec.ts
+++ b/src/syntax/select.spec.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import 'chai';
-import { checkSelect, checkInvalid, columns, ref, star, tbl, name, qname, checkStatement, int, binary } from './spec-utils';
+import { checkSelect, checkSelectLoc, checkInvalid, columns, ref, star, tbl, name, qname, checkStatement, int, binary } from './spec-utils';
 import { JoinType, SelectStatement } from './ast';
 
 describe('Select statements', () => {
@@ -1059,5 +1059,49 @@ describe('Select statements', () => {
         skip: {
             type: 'skip locked',
         }
+    });
+
+    checkSelectLoc('select * from test as t', {
+        _location: { start: 0, end: 23 },
+        type: 'select',
+        from: [{
+            _location: { start: 14, end: 23 },
+            type: 'table',
+            name: {
+                _location: { start: 14, end: 23 },
+                name: 'test',
+                alias: 't',
+            }
+        }],
+        columns: [{
+            _location: { start: 7, end: 8 },
+            expr: {
+                _location: { start: 7, end: 8 },
+                type: 'ref',
+                name: '*',
+            }
+        }]
+    });
+
+    checkSelectLoc('select * from test t', {
+        _location: { start: 0, end: 20 },
+        type: 'select',
+        from: [{
+            _location: { start: 14, end: 20 },
+            type: 'table',
+            name: {
+                _location: { start: 14, end: 20 },
+                name: 'test',
+                alias: 't',
+            },
+        }],
+        columns: [{
+            _location: { start: 7, end: 8 },
+            expr: {
+                _location: { start: 7, end: 8 },
+                type: 'ref',
+                name: '*',
+            },
+        }]
     });
 });

--- a/src/syntax/spec-utils.ts
+++ b/src/syntax/spec-utils.ts
@@ -13,6 +13,10 @@ export function checkSelect(value: string | string[], expected: SelectStatement)
     checkTree(value, expected, (p, m) => m.statement(p));
 }
 
+export function checkSelectLoc(value: string | string[], expected: SelectStatement) {
+    checkTree(value, expected, (p, m) => m.statement(p), undefined, true);
+}
+
 export function checkCreateSequence(value: string | string[], expected: CreateSequenceStatement) {
     checkTree(value, expected, (p, m) => m.statement(p));
 }


### PR DESCRIPTION
First of all, thanks for this awesome project! 

I spotted a bug with the location tracking where table aliases are not tracked if the `AS` keyword is omitted, for example:

- with the `AS` keyword.
```sql
SELECT * FROM test as t
              |_______| <- in this case, the tracking works correctly
```

- without the `AS` keyword.
```sql
SELECT * FROM test t
              |__| <- in this case, the tracking omits the ` t` part
```

I have proposed a solution that makes the test pass with a minimal change, but I'm not sure if it's the best approach, as I'm unfamiliar with the codebase, so I would really appreciate suggestions.