### PR TITLE
feat: support for `IS UNKNOWN` / `IS NOT UNKNOWN`

### DIFF
--- a/src/keywords.ts
+++ b/src/keywords.ts
@@ -5,4 +5,5 @@ export const sqlKeywords = [
 
     // added manually
     , "PRECISION"
+    , "UNKNOWN"
 ];

--- a/src/syntax/ast.ts
+++ b/src/syntax/ast.ts
@@ -862,7 +862,7 @@ export interface ExprCast extends PGNode {
 }
 
 
-export type UnaryOperator = '+' | '-' | 'NOT' | 'IS NULL' | 'IS NOT NULL' | 'IS TRUE' | 'IS FALSE' | 'IS NOT TRUE' | 'IS NOT FALSE';
+export type UnaryOperator = '+' | '-' | 'NOT' | 'IS NULL' | 'IS NOT NULL' | 'IS TRUE' | 'IS FALSE' | 'IS NOT TRUE' | 'IS NOT FALSE' | 'IS UNKNOWN' | 'IS NOT UNKNOWN';
 export interface ExprUnary extends PGNode {
     type: 'unary';
     operand: Expr;

--- a/src/syntax/expr.ne
+++ b/src/syntax/expr.ne
@@ -77,7 +77,7 @@ expr_star -> star  {% x => track(x, { type: 'ref', name: '*' }) %}
 expr_is
     -> (expr_is | expr_paren) (%kw_isnull | %kw_is %kw_null) {% x => track(x, { type: 'unary', op: 'IS NULL', operand: unwrap(x[0]) }) %}
     | (expr_is | expr_paren) (%kw_notnull | %kw_is kw_not_null)  {% x => track(x, { type: 'unary', op: 'IS NOT NULL', operand: unwrap(x[0])}) %}
-    | (expr_is | expr_paren) %kw_is %kw_not:? (%kw_true | %kw_false)  {% x => track(x, {
+    | (expr_is | expr_paren) %kw_is %kw_not:? (%kw_true | %kw_false | %kw_unknown)  {% x => track(x, {
             type: 'unary',
             op: 'IS ' + flattenStr([x[2], x[3]])
                 .join(' ')
@@ -249,6 +249,7 @@ expr_primary
     | value_keyword {% x => track(x, {type: 'keyword', keyword: toStr(x) }) %}
     | %qparam {% x => track(x, { type: 'parameter', name: toStr(x[0]) }) %}
     | %kw_default  {% x => track(x, { type: 'default'}) %}
+    | %kw_unknown {% x => track(x, { type: 'unknown' }) %}
 
 
 # LIKE-kind operators

--- a/src/syntax/expr.spec.ts
+++ b/src/syntax/expr.spec.ts
@@ -835,6 +835,18 @@ line`,
             operand: { type: 'ref', name: 'a' }
         });
 
+        checkTreeExpr('a is unknown', {
+            type: 'unary',
+            op: 'IS UNKNOWN',
+            operand: { type: 'ref', name: 'a' }
+        });
+
+        checkTreeExpr('a is not unknown', {
+            type: 'unary',
+            op: 'IS NOT UNKNOWN',
+            operand: { type: 'ref', name: 'a' }
+        });
+
     });
 
 

--- a/src/syntax/expr.spec.ts
+++ b/src/syntax/expr.spec.ts
@@ -835,6 +835,18 @@ line`,
             operand: { type: 'ref', name: 'a' }
         });
 
+        checkTreeExpr('a isnull', {
+            type: 'unary',
+            op: 'IS NULL',
+            operand: { type: 'ref', name: 'a' }
+        });
+
+        checkTreeExpr('a notnull', {
+            type: 'unary',
+            op: 'IS NOT NULL',
+            operand: { type: 'ref', name: 'a' }
+        });
+
         checkTreeExpr('a is unknown', {
             type: 'unary',
             op: 'IS UNKNOWN',


### PR DESCRIPTION
I have been reviewing this library's support for unary operators, and I noticed that `IS UNKNOWN` and `IS NOT UNKNOWN` were not supported, so I have added support for them, along with tests.

Additionally, it was not immediately clear to me if `ISNULL` and `NOTNULL` were supported, so I added tests for them. I see from the tests that these are mapped to `IS NULL` and `IS NOT NULL`.