### PR TITLE
fix: complete unary operator/expression support

### DIFF
--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -78,9 +78,15 @@ export const lexer = compile({
     op_like: /~~/, // ~~ =LIKE
     op_mod: '%',
     op_exp: '^',
-    op_others_unary: {
-        match: ['|/', '||/', '@', '~', '@-@', '@@', '#', '?-', '?|', '!!'],
-    },
+    op_square_root: '|/', // https://www.postgresql.org/docs/16/functions-math.html
+    op_cube_root: '||/', // https://www.postgresql.org/docs/16/functions-math.html
+    op_double_at: '@@', // https://www.postgresql.org/docs/16/functions-geometry.html and https://www.postgresql.org/docs/16/functions-json.html
+    op_tilde_star: '~*', // https://www.postgresql.org/docs/16/functions-matching.html
+    op_tilde: '~', // https://www.postgresql.org/docs/16/functions-bitstring.html and https://www.postgresql.org/docs/current/functions-matching.html
+    op_question_mark_dash: '?-', // https://www.postgresql.org/docs/16/functions-geometry.html
+    op_question_mark_pipe: '?|', // https://www.postgresql.org/docs/16/functions-geometry.html
+    op_hash_rangle_rangle: '#>>', // https://www.postgresql.org/docs/16/functions-json.html
+    op_hash: '#', // https://www.postgresql.org/docs/16/functions-geometry.html
     op_additive: {
         // group other additive operators
         match: ['||', '-', '#-', '&&'],
@@ -88,7 +94,10 @@ export const lexer = compile({
     op_compare: {
         // group other comparison operators
         // ... to add: "IN" and "NOT IN" that are matched by keywords
-        match: ['>', '>=', '<', '<=', '@>', '<@', '?', '?|', '?&', '#>>', '>>', '<<', '~', '~*', '!~', '!~*', '@@'],
+        match: ['>', '>=', '<', '<=', '@>', '<@', '?', '?&', '>>', '<<', '!~', '!~*'],
+    },
+    op_others_unary: {
+        match: ['@', '@-@', '!!'],
     },
     ops_others: {
         // referenced as (any other operator) in https://www.postgresql.org/docs/12/sql-syntax-lexical.html#SQL-PRECEDENCE

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -78,6 +78,9 @@ export const lexer = compile({
     op_like: /~~/, // ~~ =LIKE
     op_mod: '%',
     op_exp: '^',
+    op_others_unary: {
+        match: ['|/', '||/', '@', '~', '@-@', '@@', '#', '?-', '?|', '!!'],
+    },
     op_additive: {
         // group other additive operators
         match: ['||', '-', '#-', '&&'],

--- a/src/syntax/ast.ts
+++ b/src/syntax/ast.ts
@@ -862,7 +862,26 @@ export interface ExprCast extends PGNode {
 }
 
 
-export type UnaryOperator = '+' | '-' | 'NOT' | 'IS NULL' | 'IS NOT NULL' | 'IS TRUE' | 'IS FALSE' | 'IS NOT TRUE' | 'IS NOT FALSE';
+export type UnaryOperator = '+'
+    | '-'
+    | 'NOT'
+    | 'IS NULL'
+    | 'IS NOT NULL'
+    | 'IS TRUE'
+    | 'IS FALSE'
+    | 'IS NOT TRUE'
+    | 'IS NOT FALSE'
+    | '|/'
+    | '||/'
+    | '@'
+    | '~'
+    | '@-@'
+    | '@@'
+    | '#'
+    | '?-'
+    | '?|'
+    | '!!'
+
 export interface ExprUnary extends PGNode {
     type: 'unary';
     operand: Expr;

--- a/src/syntax/expr.ne
+++ b/src/syntax/expr.ne
@@ -87,7 +87,7 @@ expr_is
     | expr_compare {% unwrap %}
 
 
-expr_compare -> expr_binary[op_scopable[%op_compare], expr_compare, expr_range]
+expr_compare -> expr_binary[op_scopable[(%op_question_mark_pipe | %op_tilde_star | %op_tilde | %op_double_at | %op_hash_rangle_rangle | %op_compare)], expr_compare, expr_range]
 expr_range -> expr_ternary[ops_between, %kw_and, expr_range, expr_others]
 expr_others -> expr_binary[op_scopable[%ops_others], expr_others, expr_like]
 expr_like -> expr_binary[op_single[ops_like], expr_like, expr_in]
@@ -95,7 +95,7 @@ expr_in -> expr_binary[op_single[ops_in], expr_in, expr_add]
 expr_add -> expr_binary[op_scopable[(%op_plus | %op_minus | %op_additive)], expr_add, expr_mult]
 expr_mult -> expr_binary[op_scopable[(%star | %op_div | %op_mod)],  expr_mult, expr_exp]
 expr_exp -> expr_binary[op_scopable[%op_exp], expr_exp, expr_unary_add]
-expr_unary_add -> expr_left_unary[op_scopable[(%op_plus | %op_minus | %op_others_unary)], expr_unary_add, expr_various_constructs]
+expr_unary_add -> expr_left_unary[op_scopable[(%op_plus | %op_minus | %op_square_root | %op_cube_root | %op_double_at | %op_tilde | %op_question_mark_dash | %op_question_mark_pipe | %op_hash | %op_others_unary)], expr_unary_add, expr_various_constructs]
 expr_various_constructs -> expr_binary[op_single[various_binaries], expr_various_constructs, expr_array_index]
 
 expr_array_index

--- a/src/syntax/expr.ne
+++ b/src/syntax/expr.ne
@@ -95,7 +95,7 @@ expr_in -> expr_binary[op_single[ops_in], expr_in, expr_add]
 expr_add -> expr_binary[op_scopable[(%op_plus | %op_minus | %op_additive)], expr_add, expr_mult]
 expr_mult -> expr_binary[op_scopable[(%star | %op_div | %op_mod)],  expr_mult, expr_exp]
 expr_exp -> expr_binary[op_scopable[%op_exp], expr_exp, expr_unary_add]
-expr_unary_add -> expr_left_unary[op_scopable[(%op_plus | %op_minus)], expr_unary_add, expr_various_constructs]
+expr_unary_add -> expr_left_unary[op_scopable[(%op_plus | %op_minus | %op_others_unary)], expr_unary_add, expr_various_constructs]
 expr_various_constructs -> expr_binary[op_single[various_binaries], expr_various_constructs, expr_array_index]
 
 expr_array_index

--- a/src/syntax/expr.spec.ts
+++ b/src/syntax/expr.spec.ts
@@ -835,6 +835,66 @@ line`,
             operand: { type: 'ref', name: 'a' }
         });
 
+        checkTreeExpr('|/ a', {
+            type: 'unary',
+            op: '|/',
+            operand: { type: 'ref', name: 'a' }
+        });
+
+        checkTreeExpr('||/ a', {
+            type: 'unary',
+            op: '||/',
+            operand: { type: 'ref', name: 'a' }
+        });
+
+        checkTreeExpr('@ a', {
+            type: 'unary',
+            op: '@',
+            operand: { type: 'ref', name: 'a' }
+        });
+
+        checkTreeExpr('~ a', {
+            type: 'unary',
+            op: '~',
+            operand: { type: 'ref', name: 'a' }
+        });
+
+        checkTreeExpr('@-@ a', {
+            type: 'unary',
+            op: '@-@',
+            operand: { type: 'ref', name: 'a' }
+        });
+
+        checkTreeExpr('@@ a', {
+            type: 'unary',
+            op: '@@',
+            operand: { type: 'ref', name: 'a' }
+        });
+
+        checkTreeExpr('# a', {
+            type: 'unary',
+            op: '#',
+            operand: { type: 'ref', name: 'a' }
+        });
+
+        checkTreeExpr('?- a', {
+            type: 'unary',
+            op: '?-',
+            operand: { type: 'ref', name: 'a' }
+        });
+
+        checkTreeExpr('?| a', {
+            type: 'unary',
+            op: '?|',
+            operand: { type: 'ref', name: 'a' }
+        });
+
+        checkTreeExpr('!! a', {
+            type: 'unary',
+            op: '!!',
+            operand: { type: 'ref', name: 'a' }
+        });
+
     });
 
 

--- a/src/to-sql.ts
+++ b/src/to-sql.ts
@@ -1484,6 +1484,16 @@ const visitor = astVisitor<IAstFullVisitor>(m => ({
         switch (t.op) {
             case '+':
             case '-':
+            case '|/':
+            case '||/':
+            case '@':
+            case '~':
+            case '@-@':
+            case '@@':
+            case '#':
+            case '?-':
+            case '?|':
+            case '!!':
                 // prefix ops
                 visitOp(t);
                 m.expr(t.operand);


### PR DESCRIPTION
Attempt to fix #162 by implementing the remaining unary operators.

I had to tweak the lexer to keep tests passing. Not 100% about my approach there, but it's working for old and new tests.