### PR TITLE
Support selecting from unaliased sub-selects

### DIFF
--- a/src/syntax/ast.ts
+++ b/src/syntax/ast.ts
@@ -747,7 +747,7 @@ export interface FromTable extends PGNode {
 export interface FromStatement extends PGNode {
     type: 'statement';
     statement: SelectStatement;
-    alias: string;
+    alias?: string;
     lateral?: true;
     columnNames?: Name[] | nil;
     db?: null | nil;

--- a/src/syntax/select.ne
+++ b/src/syntax/select.ne
@@ -80,8 +80,8 @@ stb_table ->  table_ref stb_opts:? {% x => {
     } %}
 
 
-# Selects on subselects MUST have an alias
-stb_statement -> %kw_lateral:? selection_paren stb_opts {% x => track(x, {
+# Selects on subselects CAN have an alias
+stb_statement -> %kw_lateral:? selection_paren stb_opts:? {% x => track(x, {
     type: 'statement',
     statement: unwrap(x[1]),
     ...x[0] && { lateral: true },

--- a/src/syntax/select.spec.ts
+++ b/src/syntax/select.spec.ts
@@ -349,7 +349,6 @@ describe('Select statements', () => {
     checkInvalid('select (*) from test');
     checkInvalid('select ("*") from test');
     checkInvalid('select * from (test)');
-    checkInvalid('select * from (select id from test)'); // <== missing alias
     checkInvalid('select * from sum(DISTINCT whatever)');
 
     checkSelect('select * from (select id from test) d', {
@@ -363,6 +362,19 @@ describe('Select statements', () => {
                 columns: columns({ type: 'ref', name: 'id' }),
             },
             alias: 'd',
+        }]
+    })
+
+    checkSelect('select * from (select id from test)', {
+        type: 'select',
+        columns: columns({ type: 'ref', name: '*' }),
+        from: [{
+            type: 'statement',
+            statement: {
+                type: 'select',
+                from: [tbl('test')],
+                columns: columns({ type: 'ref', name: 'id' }),
+            },
         }]
     })
 


### PR DESCRIPTION
Historically, when selecting from a sub-select eg `select * from (select id from test) t1` Postgres required that the subquery `(select id from test)` be aliased, in this case as `t1`.

As of Postgres 16, this is no longer the case - see [this patch](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=bcedd8f5fce0b69970cf0cee7bca560833d05869) for details, or the [Postgres 16 release notes](https://www.postgresql.org/docs/release/16.0/) (search that page for "alias"). So it's now fine to just write `select * from (select id from test)`.

This PR relaxes the grammar to match that change & updates the tests accordingly.